### PR TITLE
DE6185 preview display issues

### DIFF
--- a/extension.html
+++ b/extension.html
@@ -9,7 +9,7 @@
   <!-- Extension Dependencies -->
   <link rel="stylesheet" href="https://use.typekit.net/ccb3vpa.css">
   <link href="//d1tmclqz61gqwd.cloudfront.net/styles/crds-styles-3.0.6.min.css" media="all" rel="stylesheet" type="text/css">
-  <script type="text/javascript" src="https://cdn.rawgit.com/showdownjs/showdown/1.8.6/dist/showdown.min.js"></script>
+  <script type='text/javascript' src='https://cdn.jsdelivr.net/npm/kramed@0.5.6/kramed.min.js'></script>
   <style>
     .preview {
       margin-top: 1rem;
@@ -37,10 +37,14 @@
 
   window.contentfulExtension.init(function (extension) {
     extension.window.startAutoResizer();
-    var converter = new showdown.Converter({requireSpaceBeforeHeadingText: 'true', disableForced4SpacesIndentedSublists: 'true'});
     var previewEl = document.querySelector('[data-styled-preview]');
     var body = extension.entry.fields.body || extension.entry.fields.description;
     
+    kramed.setOptions({
+      renderer: new kramed.Renderer(),
+      smartLists: true
+    });
+
     body.onValueChanged(handleContentChange)
 
     function handleContentChange(value) {
@@ -53,7 +57,7 @@
     }
 
     function convertToHtml(src) {
-      return converter.makeHtml(src);
+      return kramed(src);
     }
 
     function setDefaultMessage(preview) {

--- a/extension.html
+++ b/extension.html
@@ -1,8 +1,8 @@
 <!doctype html>
 
 <head>
-  <link href="https://static.contentful.com/app/main-62e0abc7.css" media="all" rel="stylesheet" type="text/css">
-  <link href="https://static.contentful.com/app/vendor-976872d7.css" media="all" rel="stylesheet" type="text/css">
+  <!-- <link href="https://static.contentful.com/app/main-62e0abc7.css" media="all" rel="stylesheet" type="text/css">
+  <link href="https://static.contentful.com/app/vendor-976872d7.css" media="all" rel="stylesheet" type="text/css"> -->
   <link href="https://contentful.github.io/ui-extensions-sdk/cf-extension.css" media="all" rel="stylesheet" type="text/css">
   <script type="text/javascript" src="https://unpkg.com/contentful-ui-extensions-sdk@3"></script>
 
@@ -37,7 +37,7 @@
 
   window.contentfulExtension.init(function (extension) {
     extension.window.startAutoResizer();
-    var converter = new showdown.Converter();
+    var converter = new showdown.Converter({requireSpaceBeforeHeadingText: 'true', disableForced4SpacesIndentedSublists: 'true'});
     var previewEl = document.querySelector('[data-styled-preview]');
     var body = extension.entry.fields.body || extension.entry.fields.description;
     

--- a/extension.html
+++ b/extension.html
@@ -1,8 +1,6 @@
 <!doctype html>
 
 <head>
-  <!-- <link href="https://static.contentful.com/app/main-62e0abc7.css" media="all" rel="stylesheet" type="text/css">
-  <link href="https://static.contentful.com/app/vendor-976872d7.css" media="all" rel="stylesheet" type="text/css"> -->
   <link href="https://contentful.github.io/ui-extensions-sdk/cf-extension.css" media="all" rel="stylesheet" type="text/css">
   <script type="text/javascript" src="https://unpkg.com/contentful-ui-extensions-sdk@3"></script>
 


### PR DESCRIPTION
added two parameters to showdown constructor to fix markdown for headings (space is now required or it will render has non heading text), also removed requirement with showdown to require 4 spaces on lists/sublists

Commented out Contentful styles as they were overriding and setting the `list-style-type` to `none`

parameters added and configured:

- requireSpaceBeforeHeadingText = true
- disableForced4SpacesIndentedSublists = true